### PR TITLE
Initial implementation for custom_arguments passed to Fog.

### DIFF
--- a/lib/chef/knife/cloud/fog/options.rb
+++ b/lib/chef/knife/cloud/fog/options.rb
@@ -21,13 +21,8 @@ class Chef
               :description => "Your API endpoint. Eg, for Eucalyptus it can be 'http://ecc.eucalyptus.com:8773/services/Eucalyptus'",
               :proc => Proc.new { |endpoint| Chef::Config[:knife][:api_endpoint] = endpoint }
 
-            option :custom_arguments,
-              :long => "--custom-arguments CUSTOM_ARGUMENTS",
-              :description => "Custom arguments to be passed to Fog.",
-              :proc => Proc.new {|args| Chef::Config[:knife][:custom_arguments] =  args.split(';').map{|keys| keys.split('=')}.map{|j| Hash[*j.map{|k| k.strip}]}}
           end
         end
-
       end
     end
   end

--- a/lib/chef/knife/cloud/fog/service.rb
+++ b/lib/chef/knife/cloud/fog/service.rb
@@ -47,7 +47,7 @@ class Chef
         # cloud server specific implementation methods for commands.
         def create_server(options = {})
           begin
-            add_custom_arguments(options[:server_def])
+            add_custom_attributes(options[:server_def])
             server = connection.servers.create(options[:server_def])
           rescue Excon::Errors::BadRequest => e
             response = Chef::JSONCompat.from_json(e.response.body)
@@ -124,9 +124,6 @@ class Chef
           raise Chef::Exceptions::Override, "You must override add_api_endpoint in #{self.to_s} to add endpoint in auth_params for connection"
         end
 
-        def add_custom_arguments(server_def)
-          Chef::Config[:knife][:custom_arguments].map{|args| args.map{|k,v| server_def.merge!(k.to_sym => v)}} unless Chef::Config[:knife][:custom_arguments].nil?
-        end
       end
     end
   end

--- a/lib/chef/knife/cloud/server/options.rb
+++ b/lib/chef/knife/cloud/server/options.rb
@@ -26,6 +26,11 @@ class Chef
               :short => "-N NAME",
               :long => "--node-name NAME",
               :description => "The name of the node and client to delete, if it differs from the server name. Only has meaning when used with the '--purge' option."
+
+            option :custom_attributes,
+              :long => "--custom-attributes CUSTOM_ATTRIBUTES",
+              :description => "Custom attributes to be passed to Fog.",
+              :proc => Proc.new {|args| Chef::Config[:knife][:custom_attributes] =  args.split(';').map{|keys| keys.split('=')}.map{|j| Hash[*j.map{|k| k.strip}]}}  
           end
         end
       end

--- a/lib/chef/knife/cloud/service.rb
+++ b/lib/chef/knife/cloud/service.rb
@@ -68,6 +68,10 @@ class Chef
           raise Chef::Exceptions::Override, "You must override list_images in #{self.to_s}"
         end
 
+        def add_custom_attributes(server_def)
+          Chef::Config[:knife][:custom_attributes].map{|args| args.map{|k,v| server_def.merge!(k.to_sym => v)}} unless Chef::Config[:knife][:custom_attributes].nil?
+        end
+
       end # class service
     end
   end

--- a/spec/unit/fog_service_spec.rb
+++ b/spec/unit/fog_service_spec.rb
@@ -23,18 +23,18 @@ describe Chef::Knife::Cloud::FogService do
 
   end
 
-  context "add_custom_arguments" do
+  context "add_custom_attributes" do
     before(:each) do
-      Chef::Config[:knife][:custom_arguments] = [{"state"=>"Inactive"}]
+      Chef::Config[:knife][:custom_attributes] = [{"state"=>"Inactive"}]
       @server_def = {:name=>"vm-1", :image_ref=>"123",:flavor_ref=>"2", :key_name=>"key"}
-      instance.add_custom_arguments(@server_def)
+      instance.add_custom_attributes(@server_def)
     end
 
-    it "adds the custom arguments provided to server_def" do
+    it "adds the custom attributes provided to server_def" do
       expect(@server_def.include?(:state)).to be true
     end
 
-    it "sets the provided arguments with supplied values" do
+    it "sets the provided attributes with supplied values" do
       expect(@server_def[:state] == "Inactive").to be true
     end 
   end


### PR DESCRIPTION
Please confirm this approach. 
Currently we pass the arguments with --custom-arguments "provider=openstack" format. Here provider is an actual attribute supported by Fog.
Thanks. 
